### PR TITLE
Add support for jasmine.junit_reporter.js

### DIFF
--- a/lib/phantom-jasmine/run_jasmine_test.coffee
+++ b/lib/phantom-jasmine/run_jasmine_test.coffee
@@ -30,17 +30,7 @@ runner = new PhantomJasmineRunner(page)
 page.onConsoleMessage = (msg) ->
   console.log msg
 
-  # Terminate when the reporter singals that testing is over.
-  # We cannot use a callback function for this (because page.evaluate is sandboxed),
-  # so we have to *observe* the website.
-  if msg == "ConsoleReporter finished"
-    runner.terminate()
-
 address = phantom.args[0]
 
 page.open address, (status) ->
-  if status != "success"
-    console.log "can't load the address!"
-    phantom.exit 1
-
-  # Now we wait until onConsoleMessage reads the termination signal from the log.
+  runner.terminate()


### PR DESCRIPTION
I was having issues running [jasmine.junit_reporter.js](https://github.com/larrymyers/jasmine-reporters/blob/master/src/jasmine.junit_reporter.js) with `run_jasmine_test.coffee`
#### Early termination

I had my reporters in my `SpecRunner.html` file in the following order:
- HtmlReporter
- ConsoleReporter
- JunitReporter

Because the junit reporter only writes out files when `reportRunnerResults` is called, [jasmine.console_reporter.js](https://github.com/larrymyers/jasmine-reporters/blob/master/src/jasmine.console_reporter.js) ended the jasmine run before it could write out it's test files.
#### Missing __phantom_writeFile hook

Since jasmine_junit_reporter.js runs in the browser context, it cannot write its results to a file. However, it does provide for a [hook](https://github.com/larrymyers/jasmine-reporters/blob/138a6537d3f91436b2785cb0ea0b317eab2ac7be/src/jasmine.junit_reporter.js#L159) so that we can store the file contents in an associative array. Just before `run_jasmine_test.coffee` terminates, it grabs the contents of the hash and outputs all the files to disk. The logic for this was lifted from [phantomjs-testrunner.js](https://github.com/larrymyers/jasmine-reporters/blob/138a6537d3f91436b2785cb0ea0b317eab2ac7be/test/phantomjs-testrunner.js#L113).

The code change in the pull request fixes this issue and doesn't seem to change the behaviour of the script. I ran it against the SpecRunner.html in jasmine-phantomjs as well as my specs successfully. It was also tested on on Debian 6 and Windows 7 using PhantomJS 1.8.1.
